### PR TITLE
Updated the cloudformation Template

### DIFF
--- a/templates/SNS-VPCE-Tutorial-CloudFormation.template
+++ b/templates/SNS-VPCE-Tutorial-CloudFormation.template
@@ -178,7 +178,7 @@ Resources:
       Role: !GetAtt
         - LambdaExecutionRole
         - Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '3'
   LambdaPermission1:
     Type: 'AWS::Lambda::Permission'
@@ -209,7 +209,7 @@ Resources:
       Role: !GetAtt
         - LambdaExecutionRole
         - Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: '3'
   LambdaPermission2:
     Type: 'AWS::Lambda::Permission'


### PR DESCRIPTION
As Python 2.7 has been deprecated, CF Template is getting failed. Hence python version has been changed from 2.7 to 3.9.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
